### PR TITLE
feat: Add KMP, Rabin-Karp, and Suffix Array string processing algorithms in Go

### DIFF
--- a/go/stringalg/cmd/demo/main.go
+++ b/go/stringalg/cmd/demo/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/your/module/stringalg"
+)
+
+func main() {
+	// KMP example
+	text := "ababcabcabababd"
+	pattern := "ababd"
+	fmt.Println("KMP:", stringalg.KMPSearch(text, pattern))
+
+	// Rabin-Karp example
+	fmt.Println("Rabin-Karp:", stringalg.RabinKarpSearch("abracadabra", "abra"))
+
+	// Suffix Array examples
+	s := "banana"
+	sa := stringalg.BuildSuffixArray(s)
+	lcp := stringalg.BuildLCP(s, sa)
+	fmt.Println("Suffix Array:", sa)
+	fmt.Println("LCP:", lcp)
+
+	// Find all occurrences using suffix array binary search
+	indices := stringalg.SAFindAll("abracadabra", stringalg.BuildSuffixArray("abracadabra"), "abra")
+	sort.Ints(indices)
+	fmt.Println("SA FindAll:", indices)
+}

--- a/go/stringalg/kmp.go
+++ b/go/stringalg/kmp.go
@@ -1,0 +1,47 @@
+package stringalg
+
+func KMPSearch(text, pattern string) []int {
+	if len(pattern) == 0 || len(text) == 0 || len(pattern) > len(text) {
+		return nil
+	}
+	lps := buildLPS(pattern)
+	res := make([]int, 0)
+	i, j := 0, 0
+	for i < len(text) {
+		if text[i] == pattern[j] {
+			i++
+			j++
+			if j == len(pattern) {
+				res = append(res, i-j)
+				j = lps[j-1]
+			}
+			continue
+		}
+		if j != 0 {
+			j = lps[j-1]
+		} else {
+			i++
+		}
+	}
+	return res
+}
+
+func buildLPS(p string) []int {
+	lps := make([]int, len(p))
+	length := 0
+	for i := 1; i < len(p); {
+		if p[i] == p[length] {
+			length++
+			lps[i] = length
+			i++
+		} else {
+			if length != 0 {
+				length = lps[length-1]
+			} else {
+				lps[i] = 0
+				i++
+			}
+		}
+	}
+	return lps
+}

--- a/go/stringalg/kmp_test.go
+++ b/go/stringalg/kmp_test.go
@@ -1,0 +1,28 @@
+package stringalg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKMPSearch(t *testing.T) {
+	cases := []struct {
+		text     string
+		pattern  string
+		expected []int
+	}{
+		{"ababcabcabababd", "ababd", []int{10}},
+		{"aaaaa", "aa", []int{0, 1, 2, 3}},
+		{"hello world", "world", []int{6}},
+		{"abcdef", "gh", nil},
+		{"", "a", nil},
+		{"a", "", nil},
+	}
+
+	for _, c := range cases {
+		got := KMPSearch(c.text, c.pattern)
+		if !reflect.DeepEqual(got, c.expected) {
+			t.Fatalf("KMPSearch(%q,%q)=%v want %v", c.text, c.pattern, got, c.expected)
+		}
+	}
+}

--- a/go/stringalg/rabin_karp.go
+++ b/go/stringalg/rabin_karp.go
@@ -1,0 +1,48 @@
+package stringalg
+
+// RabinKarpSearch finds all occurrences of pattern in text using the Rabin-Karp algorithm.
+// Returns the starting indices of matches.
+func RabinKarpSearch(text, pattern string) []int {
+	if len(pattern) == 0 || len(text) == 0 || len(pattern) > len(text) {
+		return nil
+	}
+	const base = 256
+	const mod = 1000000007
+
+	m := len(pattern)
+	n := len(text)
+
+	var pHash, tHash, power int64
+	power = 1
+	for i := 0; i < m; i++ {
+		pHash = (pHash*base + int64(pattern[i])) % mod
+		tHash = (tHash*base + int64(text[i])) % mod
+		if i < m-1 {
+			power = (power * base) % mod
+		}
+	}
+
+	res := make([]int, 0)
+	for i := 0; i <= n-m; i++ {
+		if pHash == tHash {
+			// Confirm by direct comparison to avoid false positives
+			match := true
+			for j := 0; j < m; j++ {
+				if text[i+j] != pattern[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				res = append(res, i)
+			}
+		}
+		if i < n-m {
+			// Slide window: remove leading char and add trailing char
+			leading := (int64(text[i]) * power) % mod
+			tHash = (tHash - leading + mod) % mod
+			tHash = (tHash*base + int64(text[i+m])) % mod
+		}
+	}
+	return res
+}

--- a/go/stringalg/rabin_karp_test.go
+++ b/go/stringalg/rabin_karp_test.go
@@ -1,0 +1,26 @@
+package stringalg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRabinKarpSearch(t *testing.T) {
+	cases := []struct {
+		text     string
+		pattern  string
+		expected []int
+	}{
+		{"abracadabra", "abra", []int{0, 7}},
+		{"aaaaa", "aa", []int{0, 1, 2, 3}},
+		{"abcdefgh", "xyz", nil},
+		{"", "a", nil},
+		{"a", "", nil},
+	}
+	for _, c := range cases {
+		got := RabinKarpSearch(c.text, c.pattern)
+		if !reflect.DeepEqual(got, c.expected) {
+			t.Fatalf("RabinKarpSearch(%q,%q)=%v want %v", c.text, c.pattern, got, c.expected)
+		}
+	}
+}

--- a/go/stringalg/suffix_array.go
+++ b/go/stringalg/suffix_array.go
@@ -1,0 +1,144 @@
+package stringalg
+
+import "sort"
+
+func BuildSuffixArray(s string) []int {
+	n := len(s)
+	if n == 0 {
+		return nil
+	}
+	sa := make([]int, n)
+	rank := make([]int, n)
+	tmp := make([]int, n)
+	for i := 0; i < n; i++ {
+		sa[i] = i
+		rank[i] = int(s[i])
+	}
+	for k := 1; k < n; k <<= 1 {
+		sort.Slice(sa, func(i, j int) bool {
+			ri, rj := rank[sa[i]], rank[sa[j]]
+			ri2, rj2 := -1, -1
+			if sa[i]+k < n {
+				ri2 = rank[sa[i]+k]
+			}
+			if sa[j]+k < n {
+				rj2 = rank[sa[j]+k]
+			}
+			if ri != rj {
+				return ri < rj
+			}
+			return ri2 < rj2
+		})
+		tmp[sa[0]] = 0
+		classes := 1
+		for i := 1; i < n; i++ {
+			prev, cur := sa[i-1], sa[i]
+			prev1, cur1 := rank[prev], rank[cur]
+			prev2, cur2 := -1, -1
+			if prev+k < n {
+				prev2 = rank[prev+k]
+			}
+			if cur+k < n {
+				cur2 = rank[cur+k]
+			}
+			if prev1 != cur1 || prev2 != cur2 {
+				classes++
+			}
+			tmp[cur] = classes - 1
+		}
+		copy(rank, tmp)
+		if classes == n {
+			break
+		}
+	}
+	return sa
+}
+
+func BuildLCP(s string, sa []int) []int {
+	n := len(s)
+	if n == 0 || len(sa) != n {
+		return nil
+	}
+	rank := make([]int, n)
+	for i := 0; i < n; i++ {
+		rank[sa[i]] = i
+	}
+	lcp := make([]int, n)
+	k := 0
+	for i := 0; i < n; i++ {
+		r := rank[i]
+		if r == n-1 {
+			k = 0
+			continue
+		}
+		j := sa[r+1]
+		for i+k < n && j+k < n && s[i+k] == s[j+k] {
+			k++
+		}
+		lcp[r] = k
+		if k > 0 {
+			k--
+		}
+	}
+	return lcp
+}
+
+func SAFindAll(s string, sa []int, pattern string) []int {
+	n, m := len(s), len(pattern)
+	if m == 0 || n == 0 || m > n {
+		return nil
+	}
+	// lower bound
+	lo, hi := 0, n
+	for lo < hi {
+		mid := (lo + hi) / 2
+		cmp := prefixCompare(s[sa[mid]:], pattern)
+		if cmp < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	start := lo
+	// upper bound
+	lo, hi = 0, n
+	for lo < hi {
+		mid := (lo + hi) / 2
+		cmp := prefixCompare(s[sa[mid]:], pattern)
+		if cmp <= 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	end := lo
+	if start >= end {
+		return nil
+	}
+	res := make([]int, 0, end-start)
+	for i := start; i < end; i++ {
+		res = append(res, sa[i])
+	}
+	sort.Ints(res)
+	return res
+}
+
+func prefixCompare(a, b string) int {
+	la, lb := len(a), len(b)
+	l := lb
+	if la < l {
+		l = la
+	}
+	for i := 0; i < l; i++ {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	if len(b) == l {
+		return 0
+	}
+	return -1
+}

--- a/go/stringalg/suffix_array_test.go
+++ b/go/stringalg/suffix_array_test.go
@@ -1,0 +1,33 @@
+package stringalg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSuffixArrayAndLCP(t *testing.T) {
+	s := "banana"
+	sa := BuildSuffixArray(s)
+	// Known suffix array for "banana": [5, 3, 1, 0, 4, 2]
+	expectedSA := []int{5, 3, 1, 0, 4, 2}
+	if !reflect.DeepEqual(sa, expectedSA) {
+		t.Fatalf("BuildSuffixArray(%q)=%v want %v", s, sa, expectedSA)
+	}
+	lcp := BuildLCP(s, sa)
+	// LCP for above SA: [1,3,0,0,2,0]
+	expectedLCP := []int{1, 3, 0, 0, 2, 0}
+	if !reflect.DeepEqual(lcp, expectedLCP) {
+		t.Fatalf("BuildLCP(%q)=%v want %v", s, lcp, expectedLCP)
+	}
+}
+
+func TestSAFindAll(t *testing.T) {
+	s := "abracadabra"
+	sa := BuildSuffixArray(s)
+	// Find all occurrences via suffix array
+	indices := SAFindAll(s, sa, "abra")
+	expected := []int{0, 7}
+	if !reflect.DeepEqual(indices, expected) {
+		t.Fatalf("SAFindAll(%q, pattern=%q)=%v want %v", s, "abra", indices, expected)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds three string searching and pattern matching algorithms implemented in Go under the go/stringalg/ directory.
Each algorithm is modular, well-documented, and includes runnable examples and unit tests for educational and practical use.

---

## Changes Made
- Implemented KMP algorithm for efficient string searching using LPS table.
- Added Rabin-Karp algorithm with rolling hash for pattern matching.
- Built Suffix Array construction with LCP array for advanced string queries.
- Included unit tests with use cases for all algorithms.
- Added optional demo under `go/stringalg/cmd/demo/` for runnable examples.

---

## Testing Instructions
### **Local Testing**
**Prerequisite:** Go installed (v1.18 or higher)

```bash
# Run all tests
go test ./go/stringalg -v

# Run demo
go run go/stringalg/cmd/demo/main.go
```
---
## Expected Output:
All tests pass with printed results for sample pattern matches and substring queries.
---

### 🔗 Related Issue
Closes #164 
---